### PR TITLE
Fix acceptFileTypes RegExp

### DIFF
--- a/src/widget/assets/js/upload-kit.js
+++ b/src/widget/assets/js/upload-kit.js
@@ -56,7 +56,7 @@
                     maxNumberOfFiles: options.maxNumberOfFiles,
                     maxFileSize: options.maxFileSize, // 5 MB
                     acceptFileTypes: options.acceptFileTypes
-                        ? new RegExp(options.acceptFileTypes)
+                        ? new RegExp(eval(options.acceptFileTypes))
                         : null,
                     process: true,
                     getNumberOfFiles: methods.getNumberOfFiles,


### PR DESCRIPTION
javascript cannot generate RegExp from String,So eval a string to regrex pattern first.