### PR TITLE
Fix message category

### DIFF
--- a/src/widget/Upload.php
+++ b/src/widget/Upload.php
@@ -59,7 +59,7 @@ class Upload extends InputWidget
     /**
      * @var string
      */
-    public $messagesCategory = 'filekit/widget';
+    public $messagesCategory = 'widget';
 
     /**
      * @throws \yii\base\InvalidConfigException


### PR DESCRIPTION
In the latest update, the following error appears:

```
The message file for category 'filekit/widget' does not exist: ...
```
To fix this either change the message category (as proposed), or add a new folder named filekit inside the translations folder.