### PR TITLE
wrong filemap in messages registration fix

### DIFF
--- a/src/widget/Upload.php
+++ b/src/widget/Upload.php
@@ -163,7 +163,7 @@ class Upload extends InputWidget
                 'sourceLanguage' => 'en-US',
                 'basePath'=> __DIR__ . '/messages',
                 'fileMap'=>[
-                    'widget'=>'widget.php'
+                    $this->messagesCategory=>'widget.php'
                 ],
             ];
         }


### PR DESCRIPTION
Now upload widget (with default messagesCategory value) tries to load messages from `yii2-file-kit/src/widget/messages/{LANGUAGE}/filekit/widget.php` instead of `yii2-file-kit/src/widget/messages/{LANGUAGE}/widget.php`
The problem is that fileMap parameter works as expected only if messagesCategory="widget".

Fixed this.