### PR TITLE
Added check $multiple param from config in Upload widget

### DIFF
--- a/src/widget/Upload.php
+++ b/src/widget/Upload.php
@@ -70,7 +70,7 @@ class Upload extends InputWidget
 
         $this->registerMessages();
 
-        if ($this->maxNumberOfFiles > 1) {
+        if ($this->maxNumberOfFiles > 1 || $this->multiple) {
             $this->multiple = true;
         }
         if ($this->hasModel()) {


### PR DESCRIPTION
I need to load only one file in multiple mode. This widget config:
```
Upload::className(),
        [
            'url' => ['/file-storage/upload'],
            'sortable' => true,
            'maxFileSize' => 10000000, // 10 MiB
            'maxNumberOfFiles' => 1,
        ]);
```
does not work because the param $maxNumberOfFiles switches multiple mode to single. I guess its magic behavior - one param implicitly change other. I suggest to check the $multiple param, in this case Upload widget works correctly:
```
Upload::className(),
        [
            'url' => ['/file-storage/upload'],
            'sortable' => true,
            'maxFileSize' => 10000000, // 10 MiB
            'maxNumberOfFiles' => 1,
            'multiple' => 'true',
        ]);
```
The backward compatibility saved.
