### PR TITLE
Fix "missing translation" error

### DIFF
--- a/src/widget/Upload.php
+++ b/src/widget/Upload.php
@@ -63,7 +63,7 @@ class Upload extends InputWidget
     /**
      * @var string
      */
-    public $messagesCategory = 'filekit/widget';
+    public $messagesCategory = 'widget';
 
     /**
      * @throws \yii\base\InvalidConfigException
@@ -162,7 +162,7 @@ class Upload extends InputWidget
      */
     protected function registerMessages()
     {
-        if (!array_key_exists($this->messagesCategory, Yii::$app->i18n->translations)) {
+        if (array_key_exists($this->messagesCategory, Yii::$app->i18n->translations)) {
             Yii::$app->i18n->translations[$this->messagesCategory] = [
                 'class' => 'yii\i18n\PhpMessageSource',
                 'sourceLanguage' => 'en-US',


### PR DESCRIPTION
* Fix message category.
* Fix message registering logic (we want to add the translation when the key EXISTS in the array).