### PR TITLE
Use fileStorage->baseUrl in case baseUrlAttribute is null

### DIFF
--- a/src/behaviors/UploadBehavior.php
+++ b/src/behaviors/UploadBehavior.php
@@ -263,6 +263,9 @@ class UploadBehavior extends Behavior
         $file = array_map(function ($attribute) {
             return $this->owner->getAttribute($attribute);
         }, $this->fields());
+        if ($file['path'] !== null && $file['base_url'] === null){
+            $file['base_url'] = $this->getStorage()->baseUrl;
+        }
         if (array_key_exists('path', $file) && $file['path']) {
             $this->owner->{$this->attribute} = $this->enrichFileData($file);
         }


### PR DESCRIPTION
When Db is migrated from one server into another old storage url is used.
You can configure your model not to use its baseUrlAttribute by specifying it to be null
and instead it will use fileStorage->baseUrl.

So it will always use current storage url.