### PR TITLE
validationRules fix error messages.

### DIFF
--- a/src/actions/UploadAction.php
+++ b/src/actions/UploadAction.php
@@ -137,7 +137,7 @@ class UploadAction extends BaseAction
 
                 } else {
                     $output['error'] = true;
-                    $output['errors'] = $validationModel->errors;
+                    $output['errors'] = $validationModel->getFirstError('file');
                 }
             } else {
                 $output['error'] = true;


### PR DESCRIPTION
Сейчас при добавлении validationRules, например:
```
'validationRules'=>[
    ['file', 'image', 'maxWidth'=>20]
],
```

Вывод ошибки происходит вот такой: 

![eecc2d1a2010a79b1747c85a181187b2](https://user-images.githubusercontent.com/11192488/27641165-c6ab656a-5c23-11e7-91cf-992db4332255.png)

$output['errors'] ожидает string, а получает массив. Скорее всего нужно сделать как в этом pull request.
В результате получаем читабельную ошибку..

![860bfb891fedd40c540bea808d8c3eea](https://user-images.githubusercontent.com/11192488/27641371-4d48fae2-5c24-11e7-9f22-a2fb68c6be1b.png)
