### PR TITLE
php 7.2 support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "minimum-stability": "dev",
     "require": {
-        "yiisoft/yii2": "^2.0.0",
+        "yiisoft/yii2": "~2.0.13",
         "yiisoft/yii2-jui": "^2.0.0",
         "league/flysystem": "^1.0",
         "bower-asset/blueimp-file-upload": "^9.7.0"

--- a/examples/AwsS3v3FlysystemBuilder.php
+++ b/examples/AwsS3v3FlysystemBuilder.php
@@ -2,13 +2,13 @@
 
 use League\Flysystem\Filesystem;
 use trntv\filekit\filesystem\FilesystemBuilderInterface;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class AwsS3v3FlysystemBuilder
  * @author Eugene Terentev <eugene@terentev.net>
  */
-class AwsS3v3FlysystemBuilder extends Object implements FilesystemBuilderInterface
+class AwsS3v3FlysystemBuilder extends BaseObject implements FilesystemBuilderInterface
 {
     public $key;
     public $secret;

--- a/examples/LocalFlysystemBuilder.php
+++ b/examples/LocalFlysystemBuilder.php
@@ -2,14 +2,14 @@
 
 use League\Flysystem\Adapter\Local;
 use League\Flysystem\Filesystem;
-use yii\base\Object;
+use yii\base\BaseObject;
 
 /**
  * Class LocalFilesystemBuilder
  * @author Eugene Terentev <eugene@terentev.net>*
  *
  */
-class LocalFilesystemBuilder extends Object implements \trntv\filekit\filesystem\FilesystemBuilderInterface
+class LocalFilesystemBuilder extends BaseObject implements \trntv\filekit\filesystem\FilesystemBuilderInterface
 {
     /**
      * @var

--- a/src/File.php
+++ b/src/File.php
@@ -3,7 +3,7 @@ namespace trntv\filekit;
 
 use yii\base\InvalidConfigException;
 use yii\base\InvalidParamException;
-use yii\base\Object;
+use yii\base\BaseObject;
 use yii\helpers\FileHelper;
 use yii\web\UploadedFile;
 
@@ -12,7 +12,7 @@ use yii\web\UploadedFile;
  * @package trntv\filekit
  * @author Eugene Terentev <eugene@terentev.net>
  */
-class File extends Object
+class File extends BaseObject
 {
     /**
      * @var


### PR DESCRIPTION
* Use `yii\base\BaseObject` instead of `yii\base\Object`
* Yii2 minimum version set to 2.0.13, due to absence `yii\base\BaseObject` in previous versions.