### PR TITLE
Support the use of name, value for widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,22 @@ echo \trntv\filekit\widget\Upload::widget([
 ]);
 ```
 
+Standalone usage - without model
+```php
+echo \trntv\filekit\widget\Upload::widget([
+    'name' => 'filename',
+    'hiddenInputId' => 'filename', // must for not use model
+    'url' => ['upload'],
+    'sortable' => true,
+    'maxFileSize' => 10 * 1024 * 1024, // 10Mb
+    'minFileSize' => 1 * 1024 * 1024, // 1Mb
+    'maxNumberOfFiles' => 3 // default 1,
+    'acceptFileTypes' => new JsExpression('/(\.|\/)(gif|jpe?g|png)$/i'),
+    'showPreviewFilename' => false,
+    'clientOptions' => [ ...other blueimp options... ]
+]);
+```
+
 With ActiveForm
 ```php
 echo $form->field($model, 'files')->widget(

--- a/src/widget/Upload.php
+++ b/src/widget/Upload.php
@@ -68,6 +68,12 @@ class Upload extends InputWidget
      * @var bool preview image file or not in the upload box.
      */
     public $previewImage = true;
+    /**
+     * custom hiddenInput id，if not set $this->options['id'] will be use.
+     * useful if use name,value
+     * @var null|string
+     */
+    public $hiddenInputId = null;
 
     /**
      * @throws \yii\base\InvalidConfigException
@@ -159,7 +165,7 @@ class Upload extends InputWidget
         $content = Html::beginTag('div');
         $content .= Html::hiddenInput($this->name, null, [
             'class' => 'empty-value',
-            'id' => $this->options['id']
+            'id' => $this->hiddenInputId === null ? $this->options['id'] : $this->hiddenInputId
         ]);
         $content .= Html::fileInput($this->getFileInputName(), null, [
             'name' => $this->getFileInputName(),


### PR DESCRIPTION
```php
<?= Upload::widget([
    'name' => 'filename',
    'url' => ['/file/upload'],
    'multiple' => false,
    'maxNumberOfFiles' => 1,
    'maxFileSize' => 5 * 1048576 // 5M
]) ?>
```
Use above, widget can not render correct.

This PR fix that.
```php
<?= Upload::widget([
    'name' => 'filename',
    'hiddenInputId' => 'filename', // add this param
    'url' => ['/file/upload'],
    'multiple' => false,
    'maxNumberOfFiles' => 1,
    'maxFileSize' => 5 * 1048576 // 5M
]) ?>
```
